### PR TITLE
feat: reportes de ventas en tiempo real

### DIFF
--- a/src/app/api/dashboard/dto.ts
+++ b/src/app/api/dashboard/dto.ts
@@ -3,7 +3,7 @@
 import { z } from "zod";
 
 export const dashboardQuerySchema = z.object({
-  view: z.enum(["daily", "range", "compare", "top"]),
+  view: z.enum(["daily", "range", "compare", "top", "now"]),
   date: z.string().optional(),
   fromDate: z.string().optional(),
   toDate: z.string().optional(),

--- a/src/features/dashboard/dashboard.dto.ts
+++ b/src/features/dashboard/dashboard.dto.ts
@@ -11,7 +11,7 @@ import { Product } from "@prisma/client";
  * @function DashboardTopData permite obtener los datos procesados de los productos mas vendidos en un rango de fecha
  * @type {ViewType} permite definir el tipo de vista que se va a renderizar
  */
-export type ViewType = "daily" | "range" | "compare" | "top";
+export type ViewType = "daily" | "range" | "compare" | "top" | "now";
 
 export interface DashboardParams {
   storeId: string;

--- a/src/features/dashboard/dashboard.service.ts
+++ b/src/features/dashboard/dashboard.service.ts
@@ -120,80 +120,81 @@ export const getDashboardData = async ({
 
       //nueva funcion, reporte actual en tiempo real
       case "now":
-        const todayStart = startOfLocalDay(new Date());
-        const todayEnd = endOfLocalDay(new Date());
-      
-        const todayOrders = await prisma.order.findMany({
-          where: {
-            storeId,
-            status: "PAID",
-            createdAt: {
-              gte: todayStart,
-              lte: todayEnd,
-            },
-          },
-          include: {
-            orderItems: {
-              include: {
-                product: true, // incluyo el costo del producto
-              },
-            },
-            payment: true, // incluyo metodo de pago
-          },
-        });
-      
-        if (todayOrders.length === 0) {
-          return {
-            totalSales: 0,
-            totalCost: 0,
-            totalProfit: 0,
-            totalOrders: 0,
-            totalProductsSold: 0,
-            byPaymentMethod: {
-              cash: 0,
-              card: 0,
-              digital: 0,
-            },
-          } satisfies AggregatedReport;
-        }
-      
-        const totalSales = todayOrders.reduce((sum, order) => {
-          const items = order.orderItems ?? [];
-          return sum + items.reduce((lineSum, item) => lineSum + Number(item.totalSalesPrice), 0);
-        }, 0);
-      
-        const totalCost = todayOrders.reduce((sum, order) => {
-          const items = order.orderItems ?? [];
-          return sum + items.reduce((lineSum, item) => lineSum + Number(item.cost), 0);
-        }, 0);
-      
-        const totalOrders = todayOrders.length;
-      
-        const totalProductsSold = todayOrders.reduce((sum, order) => {
-          const items = order.orderItems ?? [];
-          return sum + items.reduce((lineSum, item) => lineSum + item.quantity, 0);
-        }, 0);
-      
-        const byPaymentMethod = {
-          cash: todayOrders
-            .filter((o) => o.payment?.name === "CASH")
-            .reduce((sum, o) => sum + Number(o.totalAmount), 0),
-          card: todayOrders
-            .filter((o) => o.payment?.name === "CARD")
-            .reduce((sum, o) => sum + Number(o.totalAmount), 0),
-          digital: todayOrders
-            .filter((o) => o.payment?.name === "DIGITAL")
-            .reduce((sum, o) => sum + Number(o.totalAmount), 0),
-        };
-      
-        return {
-          totalSales,
-          totalCost,
-          totalProfit: totalSales - totalCost,
-          totalOrders,
-          totalProductsSold,
-          byPaymentMethod,
-        } satisfies AggregatedReport;
+        // evita que se procese fecha en una consulta a la bdd compleja.
+  const todayStart = startOfLocalDay(new Date());
+  const todayEnd = endOfLocalDay(new Date());
+
+  const todayOrders = await prisma.order.findMany({
+    where: {
+      storeId,
+      status: "PAID",
+      createdAt: {
+        gte: todayStart,
+        lte: todayEnd,
+      },
+    },
+    include: {
+      orderItems: {
+        include: {
+          product: true, // Incluimos el producto para obtener el costo
+        },
+      },
+      payment: true,
+    },
+  });
+
+  if (todayOrders.length === 0) {
+    return {
+      totalSales: 0,
+      totalCost: 0,
+      totalProfit: 0,
+      totalOrders: 0,
+      totalProductsSold: 0,
+      byPaymentMethod: {
+        cash: 0,
+        card: 0,
+        digital: 0,
+      },
+    } satisfies AggregatedReport;
+  }
+
+  const totalSales = todayOrders.reduce((sum, order) => {
+    const items = order.orderItems ?? [];
+    return sum + items.reduce((lineSum, item) => lineSum + Number(item.totalSalesPrice), 0);
+  }, 0);
+
+  const totalCost = todayOrders.reduce((sum, order) => {
+    const items = order.orderItems ?? [];
+    return sum + items.reduce((lineSum, item) => lineSum + (Number(item.product?.costPrice) || 0) * item.quantity, 0); // Multiplicamos por la cantidad
+  }, 0);
+
+  const totalOrders = todayOrders.length;
+
+  const totalProductsSold = todayOrders.reduce((sum, order) => {
+    const items = order.orderItems ?? [];
+    return sum + items.reduce((lineSum, item) => lineSum + item.quantity, 0);
+  }, 0);
+
+  const byPaymentMethod = {
+    cash: todayOrders
+      .filter((o) => o.payment?.name === "CASH")
+      .reduce((sum, o) => sum + Number(o.totalAmount), 0),
+    card: todayOrders
+      .filter((o) => o.payment?.name === "CARD")
+      .reduce((sum, o) => sum + Number(o.totalAmount), 0),
+    digital: todayOrders
+      .filter((o) => o.payment?.name === "DIGITAL")
+      .reduce((sum, o) => sum + Number(o.totalAmount), 0),
+  };
+
+  return {
+    totalSales,
+    totalCost,
+    totalProfit: totalSales - totalCost,
+    totalOrders,
+    totalProductsSold,
+    byPaymentMethod,
+  } satisfies AggregatedReport;
 
     /*
     Esta funcionalidad necesita revision!!

--- a/src/features/dashboard/dashboard.service.ts
+++ b/src/features/dashboard/dashboard.service.ts
@@ -118,6 +118,83 @@ export const getDashboardData = async ({
         topProducts: topWithDetails.filter((p): p is TopProduct => p !== null),
       } satisfies DashboardTopData;
 
+      //nueva funcion, reporte actual en tiempo real
+      case "now":
+        const todayStart = startOfLocalDay(new Date());
+        const todayEnd = endOfLocalDay(new Date());
+      
+        const todayOrders = await prisma.order.findMany({
+          where: {
+            storeId,
+            status: "PAID",
+            createdAt: {
+              gte: todayStart,
+              lte: todayEnd,
+            },
+          },
+          include: {
+            orderItems: {
+              include: {
+                product: true, // incluyo el costo del producto
+              },
+            },
+            payment: true, // incluyo metodo de pago
+          },
+        });
+      
+        if (todayOrders.length === 0) {
+          return {
+            totalSales: 0,
+            totalCost: 0,
+            totalProfit: 0,
+            totalOrders: 0,
+            totalProductsSold: 0,
+            byPaymentMethod: {
+              cash: 0,
+              card: 0,
+              digital: 0,
+            },
+          } satisfies AggregatedReport;
+        }
+      
+        const totalSales = todayOrders.reduce((sum, order) => {
+          const items = order.orderItems ?? [];
+          return sum + items.reduce((lineSum, item) => lineSum + Number(item.totalSalesPrice), 0);
+        }, 0);
+      
+        const totalCost = todayOrders.reduce((sum, order) => {
+          const items = order.orderItems ?? [];
+          return sum + items.reduce((lineSum, item) => lineSum + Number(item.cost), 0);
+        }, 0);
+      
+        const totalOrders = todayOrders.length;
+      
+        const totalProductsSold = todayOrders.reduce((sum, order) => {
+          const items = order.orderItems ?? [];
+          return sum + items.reduce((lineSum, item) => lineSum + item.quantity, 0);
+        }, 0);
+      
+        const byPaymentMethod = {
+          cash: todayOrders
+            .filter((o) => o.payment?.name === "CASH")
+            .reduce((sum, o) => sum + Number(o.totalAmount), 0),
+          card: todayOrders
+            .filter((o) => o.payment?.name === "CARD")
+            .reduce((sum, o) => sum + Number(o.totalAmount), 0),
+          digital: todayOrders
+            .filter((o) => o.payment?.name === "DIGITAL")
+            .reduce((sum, o) => sum + Number(o.totalAmount), 0),
+        };
+      
+        return {
+          totalSales,
+          totalCost,
+          totalProfit: totalSales - totalCost,
+          totalOrders,
+          totalProductsSold,
+          byPaymentMethod,
+        } satisfies AggregatedReport;
+
     /*
     Esta funcionalidad necesita revision!!
     case "compare":


### PR DESCRIPTION
Agrega el tipo de reporte "now" a los reportes previos que había.
Hasta ahora teniamos:

- "daily" trae los reportes por fecha.
- "range" trae los reportes por rango de fechas
- "top" trae los productos mas vendidos en un rango de fechas
- "compaer": aun no esta implementado solo comentado porque no pide las historias de usuario

Esta funcionalidad "now" lista todas las ventas realizadas en el dia actual aplica operaciones matemáticas y muestra los datos.
Usa el mismo endpoint de dashboard. Deben enviar por params view="now" y sin ningun otro dato.